### PR TITLE
reduce cast length

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -100,6 +100,9 @@ async def get_poster(query, bulk=False, id=False, file=None):
         plot = movie.get('plot outline')
     if plot and len(plot) > 800:
         plot = plot[0:800] + "..."
+    cast = movie.get("cast")
+    if cast:
+        cast = list_to_str(cast[:4])
 
     return {
         'title': movie.get('title'),
@@ -110,7 +113,7 @@ async def get_poster(query, bulk=False, id=False, file=None):
         'localized_title': movie.get('localized title'),
         'kind': movie.get("kind"),
         "imdb_id": f"tt{movie.get('imdbID')}",
-        "cast": list_to_str(movie.get("cast")),
+        "cast": cast,
         "runtime": list_to_str(movie.get("runtimes")),
         "countries": list_to_str(movie.get("countries")),
         "certificates": list_to_str(movie.get("certificates")),


### PR DESCRIPTION
I think nobody wants full cast and crew...So reducing it to top 4 is better..otherwise it shows full cast and crew which consumes more space and letters also kinda annoying..just like this👇
https://telegra.ph/file/e0596625238f03665b3f7.jpg
After reducing I think it is looking better
https://telegra.ph/file/be26fe65b241e8767ed34.jpg