### PR TITLE
Users Can add seperate Grp oR channel 

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,10 +46,6 @@
             "description": "Bot Logs,Give a channel id with -100xxxxxxx",
             "required": true
         },
-        "INDEX_REQ_CHANNEL": {
-            "description": "You Can Set A seperate Group/Channel for INDEX REQ and related Things. You Can Leave Here free If You Don't Want separate It. Bot Logs,Give a channel id with -100xxxxxxx",
-            "required": false
-        },
         "SUPPORT_CHAT": {
             "description": "Username of a Support Group / ADMIN. ( Should be username without @ and not ID)",
             "required": false

--- a/app.json
+++ b/app.json
@@ -46,6 +46,10 @@
             "description": "Bot Logs,Give a channel id with -100xxxxxxx",
             "required": true
         },
+        "INDEX_REQ_CHANNEL": {
+            "description": "You Can Set A seperate Group/Channel for INDEX REQ and related Things. You Can Leave Here free If You Don't Want separate It. Bot Logs,Give a channel id with -100xxxxxxx",
+            "required": false
+        },
         "SUPPORT_CHAT": {
             "description": "Username of a Support Group / ADMIN. ( Should be username without @ and not ID)",
             "required": false

--- a/info.py
+++ b/info.py
@@ -47,6 +47,7 @@ IMDB_TEMPLATE = environ.get("IMDB_TEMPLATE", "<b>Query: {query}</b> \n‌‌‌�
 LONG_IMDB_DESCRIPTION = is_enabled(environ.get("LONG_IMDB_DESCRIPTION", "False"), False)
 SPELL_CHECK_REPLY = is_enabled(environ.get("SPELL_CHECK_REPLY", "True"), True)
 MAX_LIST_ELM = environ.get("MAX_LIST_ELM", None)
+INDEX_REQ_CHANNEL = int(environ.get('INDEX_REQ_CHANNEL', 'LOG_CHANNEL'))
 
 LOG_STR = "Current Cusomized Configurations are:-\n"
 LOG_STR += ("IMDB Results are enabled, Bot will be showing imdb details for you queries.\n" if IMDB else "IMBD Results are disabled.\n")

--- a/info.py
+++ b/info.py
@@ -47,7 +47,7 @@ IMDB_TEMPLATE = environ.get("IMDB_TEMPLATE", "<b>Query: {query}</b> \n‌‌‌�
 LONG_IMDB_DESCRIPTION = is_enabled(environ.get("LONG_IMDB_DESCRIPTION", "False"), False)
 SPELL_CHECK_REPLY = is_enabled(environ.get("SPELL_CHECK_REPLY", "True"), True)
 MAX_LIST_ELM = environ.get("MAX_LIST_ELM", None)
-INDEX_REQ_CHANNEL = int(environ.get('INDEX_REQ_CHANNEL', 'LOG_CHANNEL'))
+INDEX_REQ_CHANNEL = int(environ.get('INDEX_REQ_CHANNEL', LOG_CHANNEL))
 
 LOG_STR = "Current Cusomized Configurations are:-\n"
 LOG_STR += ("IMDB Results are enabled, Bot will be showing imdb details for you queries.\n" if IMDB else "IMBD Results are disabled.\n")

--- a/plugins/index.py
+++ b/plugins/index.py
@@ -3,7 +3,8 @@ import asyncio
 from pyrogram import Client, filters
 from pyrogram.errors import FloodWait
 from pyrogram.errors.exceptions.bad_request_400 import ChannelInvalid, ChatAdminRequired, UsernameInvalid, UsernameNotModified
-from info import ADMINS, LOG_CHANNEL
+from info import ADMINS
+from info import INDEX_REQ_CHANNEL as LOG_CHANNEL
 from database.ia_filterdb import save_file
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from utils import temp


### PR DESCRIPTION
### Just few moves of commits 
users can add separate index related deatails messsages in this grp oR channel 

direct to point :
_that just added two LOG Channel 
ONE FOR ALL OTHER ACTIVITIES LIKE (bot start, new grp added)
SECOND LOg Channel for only Index related messages like(Index request) thats all_ 