### PR TITLE
if caption is longer than 1024:

### DIFF
--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -645,7 +645,11 @@ async def auto_filter(client, msg, spoll=False):
         cap = f"Here is what i found for your query {search}"
     if imdb and imdb.get('poster'):
         try:
-            await message.reply_photo(photo=imdb.get('poster'), caption=cap, reply_markup=InlineKeyboardMarkup(btn))
+            if len(cap) > 1024:
+               cap = f"Here is what i found for your Request {search}"
+               await message.reply_text(cap, reply_markup=InlineKeyboardMarkup(btn))
+            else:
+               await message.reply_photo(photo=imdb.get('poster'), caption=cap, reply_markup=InlineKeyboardMarkup(btn))
         except (MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty):
             pic = imdb.get('poster')
             poster = pic.replace('.jpg', "._V1_UX360.jpg")

--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -645,15 +645,11 @@ async def auto_filter(client, msg, spoll=False):
         cap = f"Here is what i found for your query {search}"
     if imdb and imdb.get('poster'):
         try:
-            if len(cap) > 1024:
-               cap = f"Here is what i found for your Request {search}"
-               await message.reply_text(cap, reply_markup=InlineKeyboardMarkup(btn))
-            else:
-               await message.reply_photo(photo=imdb.get('poster'), caption=cap, reply_markup=InlineKeyboardMarkup(btn))
+            await message.reply_photo(photo=imdb.get('poster'), caption=cap[:1024], reply_markup=InlineKeyboardMarkup(btn))
         except (MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty):
             pic = imdb.get('poster')
             poster = pic.replace('.jpg', "._V1_UX360.jpg")
-            await message.reply_photo(photo=poster, caption=cap, reply_markup=InlineKeyboardMarkup(btn))
+            await message.reply_photo(photo=poster, caption=cap[:1024], reply_markup=InlineKeyboardMarkup(btn))
         except Exception as e:
             logger.exception(e)
             await message.reply_text(cap, reply_markup=InlineKeyboardMarkup(btn))


### PR DESCRIPTION
ERROR - Telegram says: [400 MEDIA_CAPTION_TOO_LONG] - The media caption is longer than 1024 characters (caused by "messages.SendMedia")

this may happen if imdb['plot'] is too long